### PR TITLE
refactor: remove rxjs as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@sanity/icons": "^2.0.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.0.0",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.7"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.2.0",
@@ -3038,6 +3037,24 @@
         "rxjs": "^6.4.0"
       }
     },
+    "node_modules/@sanity/bifur-client/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@sanity/bifur-client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@sanity/block-tools": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0.tgz",
@@ -3227,6 +3244,24 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@sanity/client/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@sanity/client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@sanity/color": {
       "version": "2.1.20",
@@ -3629,15 +3664,6 @@
         "typescript": "^4.7"
       }
     },
-    "node_modules/@sanity/pkg-utils/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@sanity/plugin-kit": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@sanity/plugin-kit/-/plugin-kit-2.1.5.tgz",
@@ -4036,6 +4062,24 @@
       "peerDependencies": {
         "@sanity/client": "^3.4.1"
       }
+    },
+    "node_modules/@sanity/validation/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@sanity/validation/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.1",
@@ -5815,15 +5859,6 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/concurrently/node_modules/supports-color": {
@@ -9403,15 +9438,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/inquirer/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -10465,15 +10491,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/listr2/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/listr2/node_modules/slice-ansi": {
@@ -15855,14 +15872,12 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dev": true,
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/rxjs-etc": {
@@ -15885,11 +15900,6 @@
       "peerDependencies": {
         "rxjs": "6.x"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -16347,6 +16357,18 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/sanity/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/sanity/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -16358,6 +16380,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/sanity/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -20764,6 +20792,23 @@
       "requires": {
         "nanoid": "^3.1.12",
         "rxjs": "^6.4.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@sanity/block-tools": {
@@ -20916,6 +20961,21 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
           "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -21259,17 +21319,6 @@
         "treeify": "^1.1.0",
         "uuid": "^9.0.0",
         "zod": "^3.18.0"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@sanity/plugin-kit": {
@@ -21597,6 +21646,23 @@
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^6.5.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@semantic-release/changelog": {
@@ -22918,15 +22984,6 @@
         "yargs": "^17.3.1"
       },
       "dependencies": {
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -25448,17 +25505,6 @@
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
         "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "internal-slot": {
@@ -26206,15 +26252,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
-        },
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -30128,18 +30165,12 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.1.0"
       }
     },
     "rxjs-etc": {
@@ -30519,6 +30550,15 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -30527,6 +30567,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "@sanity/icons": "^2.0.0",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.0.0",
-    "lodash": "^4.17.21",
-    "rxjs": "^6.6.7"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.2.0",

--- a/src/loader/GoogleMapsLoadProxy.tsx
+++ b/src/loader/GoogleMapsLoadProxy.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
-import {Subscription} from 'rxjs'
-import {loadGoogleMapsApi, GoogleLoadState} from './loadGoogleMapsApi'
-import {LoadError} from './LoadError'
+import React, {useEffect, useState} from 'react'
+import {AuthError, loadGoogleMapsApi} from './loadGoogleMapsApi'
+import {LoadError as LoadErrorView} from './LoadError'
 import {GoogleMapsInputConfig} from '../index'
 
 interface LoadProps {
@@ -9,43 +8,51 @@ interface LoadProps {
   config: GoogleMapsInputConfig
 }
 
-export class GoogleMapsLoadProxy extends React.Component<LoadProps, GoogleLoadState> {
-  loadSubscription: Subscription | undefined
+const browserLocale = (typeof window !== 'undefined' && window.navigator.language) || 'en'
 
-  constructor(props: LoadProps) {
-    super(props)
-
-    this.state = {loadState: 'loading'}
-
-    let sync = true
-    this.loadSubscription = loadGoogleMapsApi(props.config).subscribe((loadState) => {
-      if (sync) {
-        this.state = loadState
-      } else {
-        this.setState(loadState)
-      }
-    })
-    sync = false
-  }
-
-  componentWillUnmount() {
-    if (this.loadSubscription) {
-      this.loadSubscription.unsubscribe()
+type LoadState =
+  | {
+      type: 'loading'
     }
-  }
-
-  render() {
-    switch (this.state.loadState) {
-      case 'loadError':
-        return <LoadError error={this.state.error} isAuthError={false} />
-      case 'authError':
-        return <LoadError isAuthError />
-      case 'loading':
-        return <div>Loading Google Maps API</div>
-      case 'loaded':
-        return this.props.children(this.state.api) || null
-      default:
-        return null
+  | {
+      type: 'loaded'
+      api: typeof window.google.maps
     }
+  | {
+      type: 'error'
+      error: {type: 'loadError' | 'authError'; message: string}
+    }
+
+function useLoadGoogleMapsApi(config: {defaultLocale?: string; apiKey: string}): LoadState {
+  const locale = config.defaultLocale || browserLocale || 'en-US'
+
+  const [state, setState] = useState<LoadState>({type: 'loading'})
+
+  useEffect(() => {
+    loadGoogleMapsApi({locale, apiKey: config.apiKey}).then(
+      (api) => setState({type: 'loaded', api}),
+      (err) =>
+        setState({
+          type: 'error',
+          error: {type: err instanceof AuthError ? 'authError' : 'loadError', message: err.message},
+        })
+    )
+  }, [locale, config.apiKey])
+  return state
+}
+
+export function GoogleMapsLoadProxy(props: LoadProps) {
+  const loadState = useLoadGoogleMapsApi(props.config)
+  switch (loadState.type) {
+    case 'error':
+      return (
+        <LoadErrorView error={loadState.error} isAuthError={loadState.error.type === 'authError'} />
+      )
+    case 'loading':
+      return <div>Loading Google Maps API</div>
+    case 'loaded':
+      return props.children(loadState.api)
+    default:
+      return null
   }
 }

--- a/src/loader/LoadError.tsx
+++ b/src/loader/LoadError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {Card, Box, Text, Code} from '@sanity/ui'
 
-type Props = {error: Error; isAuthError: false} | {isAuthError: true}
+type Props = {error: {message?: string}; isAuthError: false} | {isAuthError: true}
 
 export function LoadError(props: Props) {
   return (

--- a/src/loader/loadGoogleMapsApi.ts
+++ b/src/loader/loadGoogleMapsApi.ts
@@ -1,6 +1,3 @@
-import {Observable, BehaviorSubject} from 'rxjs'
-import {GoogleMapsInputConfig} from '../index'
-
 declare global {
   interface Window {
     gm_authFailure: any
@@ -10,78 +7,57 @@ declare global {
 
 const callbackName = '___sanity_googleMapsApiCallback'
 const authFailureCallbackName = 'gm_authFailure'
-const locale = (typeof window !== 'undefined' && window.navigator.language) || 'en'
 
-export interface LoadingState {
-  loadState: 'loading'
-}
+export class AuthError extends Error {}
 
-export interface LoadedState {
-  loadState: 'loaded'
-  api: typeof window.google.maps
-}
+function _loadGoogleMapsApi(config: {locale: string; apiKey: string}) {
+  return new Promise<typeof window.google.maps>((resolve, reject) => {
+    window[authFailureCallbackName] = () => {
+      reject(new AuthError('Authentication error when loading Google Maps API.'))
+    }
 
-export interface LoadErrorState {
-  loadState: 'loadError'
-  error: Error
-}
+    window[callbackName] = () => {
+      resolve(window.google.maps)
+    }
 
-export interface AuthErrorState {
-  loadState: 'authError'
-}
+    const script = document.createElement('script')
+    script.onerror = (
+      event: Event | string,
+      source?: string,
+      lineno?: number,
+      colno?: number,
+      error?: Error
+    ) => reject(new Error(coeerceError(event, error)))
 
-export type GoogleLoadState = LoadingState | LoadedState | LoadErrorState | AuthErrorState
-
-let subject: BehaviorSubject<GoogleLoadState>
-
-export function loadGoogleMapsApi(config: GoogleMapsInputConfig): Observable<GoogleLoadState> {
-  const selectedLocale = config.defaultLocale || locale || 'en-US'
-
-  if (subject) {
-    return subject
-  }
-
-  subject = new BehaviorSubject<GoogleLoadState>({loadState: 'loading'})
-
-  window[authFailureCallbackName] = () => {
-    delete window[authFailureCallbackName]
-    subject.next({loadState: 'authError'})
-  }
-
-  window[callbackName] = () => {
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${config.apiKey}&libraries=places&callback=${callbackName}&language=${config.locale}`
+    document.getElementsByTagName('head')[0].appendChild(script)
+  }).finally(() => {
     delete window[callbackName]
-    subject.next({loadState: 'loaded', api: window.google.maps})
-  }
-
-  const script = document.createElement('script')
-  script.onerror = (
-    event: Event | string,
-    source?: string,
-    lineno?: number,
-    colno?: number,
-    error?: Error
-  ) =>
-    subject.next({
-      loadState: 'loadError',
-      error: coeerceError(event, error),
-    } as LoadErrorState)
-
-  script.src = `https://maps.googleapis.com/maps/api/js?key=${config.apiKey}&libraries=places&callback=${callbackName}&language=${selectedLocale}`
-  document.getElementsByTagName('head')[0].appendChild(script)
-
-  return subject
+    delete window[authFailureCallbackName]
+  })
 }
 
-function coeerceError(event: Event | string, error?: Error): Error {
+let memo: Promise<typeof window.google.maps> | null = null
+export function loadGoogleMapsApi(config: {locale: string; apiKey: string}) {
+  if (memo) {
+    return memo
+  }
+  memo = _loadGoogleMapsApi(config)
+  memo.catch(() => {
+    memo = null
+  })
+  return memo
+}
+function coeerceError(event: Event | string, error?: Error): string {
   if (error) {
-    return error
+    return error.message
   }
 
   if (typeof event === 'string') {
-    return new Error(event)
+    return event
   }
 
-  return new Error(isErrorEvent(event) ? event.message : 'Failed to load Google Maps API')
+  return isErrorEvent(event) ? event.message : 'Failed to load Google Maps API'
 }
 
 function isErrorEvent(event: unknown): event is ErrorEvent {


### PR DESCRIPTION
This refactors out the dependency on rxjs and replaces its usage with a promise based flow. I've tested in a real studio and verified that everything regarding loading of the Google Maps API works as it used to.