### PR TITLE
feat: add optional saveZoom parameter to persist the selected zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ And that the key allows web-access from the Studio URL(s) you are using the plug
 
 Note: This plugin will replace the default `geopoint` input component.
 
+## Store selected Zoom
+
+Optionally persists the selected zoom.
+
+```js
+import {googleMapsInput} from '@sanity/google-maps-input'
+
+export default defineConfig({
+  // ...
+  plugins: [
+    googleMapsInput({
+      saveZoom: true, // default false
+      apiKey: 'my-api-key',
+    }),
+  ],
+})
+```
+
+Adds a `zoom` property in `geopoint` object.
+
+```json
+{
+  "_type": "geopoint",
+  "lat": 54.5259614,
+  "lng": 15.2551187,
+  "zoom": 3
+}
+```
+
+
 ## Stuck? Get help
 
 [![Slack Community Button](https://slack.sanity.io/badge.svg)](https://slack.sanity.io/)

--- a/src/input/GeopointInput.tsx
+++ b/src/input/GeopointInput.tsx
@@ -10,13 +10,13 @@ import {DialogInnerContainer, PreviewImage} from './GeopointInput.styles'
 import {GoogleMapsInputConfig} from '../index'
 import {getGeoConfig} from '../global-workaround'
 
-const getStaticImageUrl = (value: LatLng, apiKey: string) => {
+const getStaticImageUrl = (value: LatLng, apiKey: string, zoom?: number) => {
   const loc = `${value.lat},${value.lng}`
   const params = {
     key: apiKey,
     center: loc,
     markers: loc,
-    zoom: 13,
+    zoom: zoom || 13,
     scale: 2,
     size: '640x300',
   } as const
@@ -79,6 +79,16 @@ class GeopointInput extends React.PureComponent<GeopointInputProps, InputState> 
     ])
   }
 
+  handleZoomChange = (zoom: number) => {
+    const {schemaType, onChange} = this.props
+    onChange([
+      setIfMissing({
+        _type: schemaType.name,
+      }),
+      set(zoom, ['zoom']),
+    ])
+  }
+
   handleClear = () => {
     const {onChange} = this.props
     onChange(unset())
@@ -113,7 +123,10 @@ class GeopointInput extends React.PureComponent<GeopointInputProps, InputState> 
       <>
         {value && (
           <ChangeIndicator path={path} isChanged={changed} hasFocus={!!focused}>
-            <PreviewImage src={getStaticImageUrl(value, config.apiKey)} alt="Map location" />
+            <PreviewImage
+              src={getStaticImageUrl(value, config.apiKey, value.zoom)}
+              alt="Map location"
+            />
           </ChangeIndicator>
         )}
 
@@ -157,8 +170,9 @@ class GeopointInput extends React.PureComponent<GeopointInputProps, InputState> 
                     api={api}
                     value={value || undefined}
                     onChange={readOnly ? undefined : this.handleChange}
+                    onZoomChange={readOnly || !config.saveZoom ? undefined : this.handleZoomChange}
                     defaultLocation={config.defaultLocation}
-                    defaultZoom={config.defaultZoom}
+                    defaultZoom={value?.zoom || config.defaultZoom}
                   />
                 )}
               </GoogleMapsLoadProxy>

--- a/src/input/GeopointSelect.tsx
+++ b/src/input/GeopointSelect.tsx
@@ -10,6 +10,7 @@ interface SelectProps {
   api: typeof window.google.maps
   value?: Geopoint
   onChange?: (latLng: google.maps.LatLng) => void
+  onZoomChange?: (zoom: number) => void
   defaultLocation?: LatLng
   defaultZoom?: number
 }
@@ -44,9 +45,19 @@ export class GeopointSelect extends React.PureComponent<SelectProps> {
     if (event.latLng) this.setValue(event.latLng)
   }
 
+  handleZoomChange = (zoom: number) => {
+    this.setZoom(zoom)
+  }
+
   setValue(geoPoint: google.maps.LatLng) {
     if (this.props.onChange) {
       this.props.onChange(geoPoint)
+    }
+  }
+
+  setZoom(zoom: number) {
+    if (this.props.onZoomChange) {
+      this.props.onZoomChange(zoom)
     }
   }
 
@@ -57,6 +68,7 @@ export class GeopointSelect extends React.PureComponent<SelectProps> {
         api={api}
         location={this.getCenter()}
         onClick={this.handleMapClick}
+        onZoomChange={this.handleZoomChange}
         defaultZoom={defaultZoom}
       >
         {(map) => (

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -8,6 +8,7 @@ export interface GoogleMapsInputConfig {
   apiKey: string
   defaultZoom?: number
   defaultLocale?: string
+  saveZoom?: boolean
   defaultLocation?: {
     lat: number
     lng: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Geopoint {
   lat: number
   lng: number
   alt?: number
+  zoom?: number
 }
 
 export interface GeopointSchemaType extends ObjectSchemaType {


### PR DESCRIPTION
This feature will add a parallel onZoomChange prop to handle zoom changes and only saves on the geopoint object if enabled.