### PR TITLE
fix(deps): use caret for styled-components peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       "peerDependencies": {
         "react": "^18",
         "sanity": "^3.19.0",
-        "styled-components": "6.1"
+        "styled-components": "^6.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "peerDependencies": {
     "react": "^18",
     "sanity": "^3.19.0",
-    "styled-components": "6.1"
+    "styled-components": "^6.1"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Discovered I did a silly little mistake in #68 and forgot to add a caret to the accepted version range of the styled-components peer dependency.